### PR TITLE
Fix Base.hash to define proper two-arg method for SurrealFinite

### DIFF
--- a/src/SurrealFinite.jl
+++ b/src/SurrealFinite.jl
@@ -110,7 +110,7 @@ end
 function hash( L::Vector{SurrealFinite}, R::Vector{SurrealFinite})
     return hash(L, zero(HashType) ) * hash(R, one(HashType) )
 end
-hash(x::SurrealFinite, h::Integer) = hash(x, convert(HashType, h) )
+hash(x::SurrealFinite, h::UInt) = hash(x.h, h)
 function hash(X::Vector{SurrealFinite}) # effectively depth first???
     H = hash(zero(HashType))
     for x in X


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

## Summary

The existing `hash(x::SurrealFinite, h::Integer)` method has two problems:

1. **Infinite recursion on 64-bit**: Since `UInt <: Integer` and `HashType = UInt64 = UInt` on 64-bit, calling `hash(x::SurrealFinite, h::UInt)` dispatches to this method, which calls `hash(x, convert(HashType, h))` — a no-op conversion that recurses infinitely.
2. **No proper two-arg `Base.hash`**: The one-arg `hash(x::SurrealFinite)` shadows this, but the two-arg fallback uses `objectid`-based hashing, breaking hash chaining in containers.

With Julia 1.13+, the default hash seed is changing from `zero(UInt)` to a random value, which will make the one-arg method produce different results each session.

## Fix

Replace the `h::Integer` method with a proper `hash(x::SurrealFinite, h::UInt) = hash(x.h, h)` that accesses the cached hash value directly (always set by the constructor) and chains it through the seed.

## Test plan

- The constructor always sets `x.h` before returning, so `x.h` is never 0 after construction
- The one-arg method remains for internal caching use

---
This PR was generated with the assistance of generative AI.

Co-Authored-By: Claude <noreply@anthropic.com>